### PR TITLE
Fix Google OAuth callback error, remove pry from sessions controller

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,5 @@
 class SessionsController < ApplicationController
   def create
-    binding.pry
     user = BackendService.user_create_or_find(user_params)
     session[:user_id] = user_params[:google_id]
     redirect_to user_path


### PR DESCRIPTION
Fixed callback error by updating allowed URIs in Google Console

Pry in SessionsController hangs up production - need to redeploy to heroku