### PR TITLE
Trail show map

### DIFF
--- a/app/facades/trail_facade.rb
+++ b/app/facades/trail_facade.rb
@@ -1,6 +1,5 @@
 class TrailFacade
   def self.search_trails(uri)
-    # binding.pry
     @trails = filter_trails(uri)[:data].map do |trail|
       Trail.new(trail)
     end
@@ -13,7 +12,6 @@ class TrailFacade
       Brewery.new(brewery)
     end
     trail_breweries = {trail => breweries}
-    # binding.pry
   end
 
   def self.filter_trails(uri)

--- a/app/poros/trail.rb
+++ b/app/poros/trail.rb
@@ -2,14 +2,16 @@ class Trail
   attr_reader :id,
               :type,
               :name,
-              :coordinates,
+              :latitude,
+              :longitude,
               :bathrooms
 
   def initialize(data)
     @id = data[:id]
     @type =data[:type]
     @name = data[:attributes][:name]
-    @coordinates = data[:attributes][:coordinates]
+    @latitude = data[:attributes][:latitude]
+    @longitude = data[:attributes][:longitude]
     @bathrooms = data[:attributes][:bathrooms]
   end
 end

--- a/app/poros/trail.rb
+++ b/app/poros/trail.rb
@@ -4,7 +4,8 @@ class Trail
               :name,
               :latitude,
               :longitude,
-              :bathrooms
+              :bathrooms,
+              :co_id
 
   def initialize(data)
     @id = data[:id]
@@ -13,5 +14,6 @@ class Trail
     @latitude = data[:attributes][:latitude]
     @longitude = data[:attributes][:longitude]
     @bathrooms = data[:attributes][:bathrooms]
+    @co_id = data[:co_id]
   end
 end

--- a/app/views/breweries/index.html.erb
+++ b/app/views/breweries/index.html.erb
@@ -14,9 +14,6 @@
               <tr>
                 <th><%=link_to brewery.name, brewery_path(brewery.id) %></th>
               </tr>
-              <tr>
-                <th>Test</th>
-              </tr>
             </thead>
           </tbody>
         <% end %>

--- a/app/views/breweries/show.html.erb
+++ b/app/views/breweries/show.html.erb
@@ -12,7 +12,6 @@
         <h3>Website: <%= @brewery.website %> </h3>
       <% end %>
 
-      <% unless @brewery.latitude.nil? || @brewery.longitude.nil? %>
         <iframe
           width="600"
           height="450"
@@ -20,11 +19,9 @@
           loading="lazy"
           allowfullscreen
           referrerpolicy="no-referrer-when-downgrade"
-          src=<%="https://www.google.com/maps/embed/v1/place?key=#{ENV['GOOGLE_API_KEY']}&q=#{@brewery.latitude},#{@brewery.longitude}" %>>
+          src=<%="https://www.google.com/maps/embed/v1/place?key=#{ENV['GOOGLE_API_KEY']}&q=#{@brewery.name.downcase.gsub(" ", "+")}" %>>
         </iframe>
-      <% else %> 
-        <h2> Missing coordinates </h2>
-      <% end %>
+     
     </div>
   </div>
 </div>

--- a/app/views/trails/index.html.erb
+++ b/app/views/trails/index.html.erb
@@ -14,9 +14,6 @@
               <tr>
                 <th><%=link_to trail.name, trail_path(trail.id) %></th>
               </tr>
-              <tr>
-                <th>Test</th>
-              </tr>
             </thead>
           </tbody>
         <% end %>

--- a/app/views/trails/show.html.erb
+++ b/app/views/trails/show.html.erb
@@ -14,8 +14,7 @@
       <hr>
       <p>Lorem ipsum...</p>
       <h3>Trail length:</h3>
-      <% a = @trail.coordinates.split(",").first %>
-      <% b = @trail.coordinates.split(",").last %>
+
       <iframe
         width="600"
         height="450"
@@ -23,7 +22,7 @@
         loading="lazy"
         allowfullscreen
         referrerpolicy="no-referrer-when-downgrade"
-        src=<%="https://www.google.com/maps/embed/v1/place?key=#{ENV['GOOGLE_API_KEY']}&q=#{a},#{b}" %>
+        src=<%="https://www.google.com/maps/embed/v1/place?key=#{ENV['GOOGLE_API_KEY']}&q=#{@trail.latitude},#{@trail.longitude}" %>
       </iframe>
     </div>
     <div class="col-sm-2 sidenav">

--- a/app/views/trails/show.html.erb
+++ b/app/views/trails/show.html.erb
@@ -12,9 +12,6 @@
     </div>
     <div class="col-sm-8 text-left"> 
       <hr>
-      <p>Lorem ipsum...</p>
-      <h3>Trail length:</h3>
-
       <iframe
         width="600"
         height="450"
@@ -22,8 +19,9 @@
         loading="lazy"
         allowfullscreen
         referrerpolicy="no-referrer-when-downgrade"
-        src=<%="https://www.google.com/maps/embed/v1/place?key=#{ENV['GOOGLE_API_KEY']}&q=#{@trail.latitude},#{@trail.longitude}" %>
+        src=<%="https://www.google.com/maps/embed/v1/place?key=#{ENV['GOOGLE_API_KEY']}&q=#{@trail.latitude},#{@trail.longitude}" %>>
       </iframe>
+    <h3>More info about <%= @trail.name %> here: <%= link_to "COTREX Hiking App", "https://trails.colorado.gov/trailheads/#{@trail.name.downcase.gsub(" ", "-")}-#{@trail.co_id}" %></h3>
     </div>
     <div class="col-sm-2 sidenav">
       <div class="well">


### PR DESCRIPTION
This PR
- Separates the coordinates in the Trail poro so that latitude and longitude are separate attributes. This helps with using the coordinates to query the embed google maps in the show page.
- Adds a link to the Trail show page that sends the user to COTREX web app that contains more info on the trail. This was done as an alternative to displaying trail data on the page instead. There wasn't a straightforward way to do that with the geojson files.
- From the trails and breweries index search pages, removed 'test' that would display between each result.
- In brewery show page, changed the query values in the google map embed from coordinates to the brewery name. This way the resulting map displays the brewery's name instead of the coordinates.